### PR TITLE
typo fix and removed unavailable config option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+.docusaurus
+.DS_Store
+.vscode/*

--- a/README.md
+++ b/README.md
@@ -1,8 +1,59 @@
-# GaiaNet Docs
 
+# GaiaNet Docs
+   
 The documentation is for GaiaNet node operators, users, and creators.
 
-Feel free to create a PR if there is anything that needs to be improved.
+## Contributing   
 
+We welcome contributions to improve our documentation! Here's how you can contribute:   
+1. Fork the repository:  
+	- Visit the [GaiaNet docs repository](https://github.com/GaiaNet-AI/docs) on GitHub 
+	- Click the "Fork" button in the top-right corner 
+	- Select where you want to fork the repository (your personal account or an organization)   
+2. Clone your forked repository:`
 
+    ```
+    git clone https://github.com/YOUR-USERNAME/docs.git
+    cd docs
+3. Create a new branch for your changes:`
+	```
+	git checkout -b your-feature-branch
+	```
 
+4. Make your changes to the documentation  
+5. Commit your changes:`
+	```
+	git add . 
+	git commit -m "Description of your changes"
+6. Push your changes to your fork:
+	```
+	git push origin your-feature-branch
+7. Create a pull request: 
+	- Go to your fork on GitHub 
+	- Click "Pull request" and select "New pull request" 
+	- Select your feature branch and submit the pull request   
+	Please ensure your contributions align with our documentation style and standards. 
+
+## Running the Documentation Locally   
+After forking and cloning the repository:   
+1. Install dependencies:
+	```
+	npm install
+2. Start the development server:
+	```
+	npm start
+3. Open your browser and visit `http://localhost:3000`   
+
+## Structure   
+- `docs/`: Contains all the markdown files for the documentation 
+- `src/`: Custom React components and pages 
+- `static/`: Static assets like images 
+- `docusaurus.config.js`: Main configuration file for Docusaurus   
+
+## Deployment   
+This documentation is automatically deployed to [docs.gaianet.ai](https://docs.gaianet.ai) when changes are merged into the main branch.   
+
+## Need Help?   
+If you have any questions or need assistance, please open an issue in this repository or reach out through our community channels.  
+ 
+Thank you for contributing to GaiaNet's documentation!

--- a/docs/node-guide/customize.md
+++ b/docs/node-guide/customize.md
@@ -79,7 +79,6 @@ gaianet config \
   --snapshot https://huggingface.co/datasets/gaianet/london/resolve/main/london_768_nomic-embed-text-v1.5-f16.snapshot.tar.gz \
   --embedding-url https://huggingface.co/gaianet/Nomic-embed-text-v1.5-Embedding-GGUF/resolve/main/nomic-embed-text-v1.5.f16.gguf \
   --embedding-ctx-size 8192 \
-  --embedding-batch-size 8192 \
   --system-prompt "You are a tour guide in London, UK. Please answer the question from a London visitor accurately." \
   --rag-prompt "The following text is the context for the user question.\n----------------\n"
 ```

--- a/docs/node-guide/install_uninstall.md
+++ b/docs/node-guide/install_uninstall.md
@@ -26,7 +26,7 @@ The GaiaNet node will be installed in your `$HOME/gaianet` folder by default.
 > # Assume that you're in the root directory
 > mkdir test
 > curl -sSfL 'https://github.com/GaiaNet-AI/gaianet-node/releases/latest/download/install.sh' | bash -s --  --base $HOME/test
-> gaianet init --base $HOME/testtest
+> gaianet init --base $HOME/test
 > gaianet start --base $HOME/test
 > gaianet stop --base $HOME/test
 > ```


### PR DESCRIPTION
Removed the word `test` written twice in the command. This is in the [Install and Uninstall](https://docs.gaianet.ai/node-guide/install_uninstall) page.

![image](https://github.com/user-attachments/assets/f03c0630-fb4b-43e4-b96d-6a17032c4182)

Removed `--embedding-batch-size` from the config list as it is not a support config option for a node. This is in the [Customize Your GaiaNet Node](https://docs.gaianet.ai/node-guide/customize) page.

![image](https://github.com/user-attachments/assets/287fdf0d-3313-4eb5-a7ab-1d5fa92f6018)
