### PR TITLE
Update nodes.md

### DIFF
--- a/docs/user-guide/nodes.md
+++ b/docs/user-guide/nodes.md
@@ -55,7 +55,7 @@ Replace OpenAI configuration in [your app](apps/intro) with the following.
 
 Coming soon!
 
-## Coding assistant agnets
+## Coding assistant agents
 
 ### Coder
 


### PR DESCRIPTION
Update with the correct typo.

At the [Public GaiaNet nodes docs page](https://docs.gaianet.ai/user-guide/nodes) there is small typo.
fixed this from "**agnets**" to "**agents**"
![image](https://github.com/user-attachments/assets/4f1e6233-62d4-4519-8ce7-9ff19d33b0c5)
