### PR TITLE
404 Fixes and API key updates

### DIFF
--- a/docs/agent-integrations/intro.md
+++ b/docs/agent-integrations/intro.md
@@ -8,6 +8,12 @@ Since each Gaia node provides an OpenAI-compatible API service, it can be a drop
 
 ## The OpenAI Python library
 
+:::note
+
+    Make sure to replace `YOUR_API_KEY_GOES_HERE` with your **own API key**. To get your own API key, follow [this](../getting-started/authentication) tutorial.
+
+:::
+
 You can install the [official OpenAI Python library](https://pypi.org/project/openai/) as follows.
 
 ```
@@ -20,19 +26,20 @@ Remember to append the `/v1` after the host name. You can find a list of public 
 ```
 import openai
 
-client = openai.OpenAI(base_url="https://YOUR-NODE-ID.us.gaianet.network/v1", api_key="")
+client = openai.OpenAI(base_url="https://YOUR-NODE-ID.us.gaianet.network/v1", api_key="YOUR_API_KEY_GOES_HERE")
 ```
 
-Alternatively, you could set an environment variable at the OS level.
+Alternatively, you could set an environment variables at the OS level.
 
 ```
 export OPENAI_API_BASE=https://YOUR-NODE-ID.us.gaianet.network/v1
+export OPENAI_API_KEY=YOUR_API_KEY_GOES_HERE
 ```
 
 Then, when you make API calls from the `client`, make sure that the `model` is set to the model name
 available on your node.
 
-```
+```py
 response = client.chat.completions.create(
     model="Meta-Llama-3-8B-Instruct-Q5_K_M",
     messages=[
@@ -50,6 +57,12 @@ as its backend!
 
 ## The OpenAI Node API library
 
+:::note
+
+    Make sure to replace `YOUR_API_KEY_GOES_HERE` with your **own API key**. To get your own API key, follow [this](../getting-started/authentication) tutorial.
+
+:::
+
 You can install the [OpenAI Node library](https://www.npmjs.com/package/openai) which provides convenient access to the OpenAI REST API from TypeScript or JavaScript as follows:
 
 ```
@@ -57,17 +70,17 @@ npm install openai
 ```
 
 Import it into your project as:
-```
+```js
 // Example usage in Node.js
 const OpenAI = require('openai');
 ```
 
 Create an OpenAI client with a custom base URL. Remember to append the `/v1` after the host name.
 
-```
+```js
 const client = new OpenAI({
   baseURL: 'https://YOUR-NODE-ID.us.gaianet.network/v1',
-  apiKey: '' // Leave this empty when using Gaia
+  apiKey: 'YOUR_API_KEY_GOES_HERE'
 });
 ```
 
@@ -79,7 +92,7 @@ process.env.OPENAI_API_BASE = 'https://YOUR-NODE-ID.us.gaianet.network/v1';
 Then, when you make API calls from the `client`, make sure that the `model` is set to the model name
 available on your node.
 
-```
+```js
 async function callOpenAI() {
   try {
     const response = await client.chat.completions.create({

--- a/docs/getting-started/api-reference.md
+++ b/docs/getting-started/api-reference.md
@@ -11,6 +11,12 @@ can also replace OpenAI API configuration with the Gaia node API in other AI age
 
 The base URL to send all API requests is `https://node_id.gaianet.network/v1`.
 
+:::note
+
+    Make sure to replace `YOUR_API_KEY_GOES_HERE` with your **own API key**. To get your own API key, follow [this](./authentication) tutorial.
+
+:::
+
 ## Endpoints
 
 ### Chat
@@ -27,6 +33,7 @@ By default, the API responds with a full answer in the HTTP response.
 curl -X POST https://node_id.gaianet.network/v1/chat/completions \
   -H 'accept:application/json' \
   -H 'Content-Type: application/json' \
+  -H 'Authorization: Bearer YOUR_API_KEY_GOES_HERE' \
   -d '{"messages":[{"role":"system", "content": "You are a helpful assistant."}, {"role":"user", "content": "What is the capital of France?"}], "model": "model_name"}'
 ```
 
@@ -46,6 +53,7 @@ Add `"stream":true` in your request to make the API send back partial responses 
 curl -X POST https://node_id.gaianet.network/v1/chat/completions \
   -H 'accept:application/json' \
   -H 'Content-Type: application/json' \
+  -H 'Authorization: Bearer YOUR_API_KEY_GOES_HERE' \
   -d '{"messages":[{"role":"system", "content": "You are a helpful assistant."}, {"role":"user", "content": "What is the capital of France?"}], "model": "model_name", "stream":true}'
 ```
 
@@ -102,6 +110,7 @@ The `embeddings` endpoint computes embeddings for user queries or file chunks.
 curl -X POST https://node_id.gaianet.network/v1/embeddings \
     -H 'accept:application/json' \
     -H 'Content-Type: application/json' \
+    -H 'Authorization: Bearer YOUR_API_KEY_GOES_HERE' \
     -d '{"model": "nomic-embed-text-v1.5.f16", "input":["Paris, city and capital of France, ..., for Paris has retained its importance as a centre for education and intellectual pursuits.", "Paris’s site at a crossroads ..., drawing to itself much of the talent and vitality of the provinces."]}'
 ```
 
@@ -161,6 +170,7 @@ The `retrieve` endpoint can retrieve text from the node's vector collection base
 curl -X POST https://node_id.gaianet.network/v1/retrieve \
     -H 'accept:application/json' \
     -H 'Content-Type: application/json' \
+    -H 'Authorization: Bearer YOUR_API_KEY_GOES_HERE' \
     -d '{"messages":[{"role":"system", "content": "You are a helpful assistant."}, {"role":"user", "content": "What is the location of Paris?"}], "model":"nomic-embed-text-v1.5.f16"}'
 ```
 

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -79,6 +79,8 @@ const config = {
           { from: '/node-guide/quick-start', to: '/getting-started/quick-start' },
           { from: '/node-guide/install_uninstall', to: '/getting-started/install' },
           { from: '/node-guide/system-requirements', to: '/getting-started/system-requirements' },
+          { from: '/getting-started/quick-start/system-requirements', to: '/getting-started/system-requirements' },
+          { from: '/getting-started/system-requirements/advanced-deployment-options/cuda', to: '/getting-started/advanced-deployment-options/cuda' },
           { from: '/node-guide/customize', to: '/getting-started/customize' },
           { from: '/node-guide/register', to: '/getting-started/register' },
           { from: '/node-guide/cli-options', to: '/getting-started/cli-options' },


### PR DESCRIPTION
Following updates have been made as part of this PR:

1. Updated code snippets to show API key usage in the https://docs.gaianet.ai/agent-integrations/intro page.
2. Fixed 404 issues in the https://docs.gaianet.ai/getting-started/system-requirements/ page & updated redirects in the docusaurs setup.
3. Updated API Key usage references in the https://docs.gaianet.ai/getting-started/api-reference cURL commands.