### PR TITLE
Fix typos and grammatical improvements across documentation

### DIFF
--- a/docs/intro.md
+++ b/docs/intro.md
@@ -29,7 +29,7 @@ If you are an end user of AI agent applications, you can:
 If you are interested in running Gaia nodes, you can
 
 * [Get started with a Gaia node](./getting-started/quick-start).
-* [Customize the Gaia node with a finetuned model and custom knowledge base](./getting-started/customize).
+* [Customize the Gaia node with a fine-tuned model and custom knowledge base](./getting-started/customize).
 * [Join the Gaia Protocol](./getting-started/register)
 
 ### Domain operators
@@ -44,4 +44,4 @@ If you are a Gaia Domain Name owner, you can
 If you are a creator or knowledge worker interested in creating your own AI agent service, you can:
 
 * [Create your own knowledge base](./knowledge-bases).
-* [Finetune a model to "speak" like you](./tutorial/llamacpp).
+* [Fine-tune a model to "speak" like you](./tutorial/llamacpp).

--- a/versioned_docs/version-1.0.0/creator-guide/finetune/intro.md
+++ b/versioned_docs/version-1.0.0/creator-guide/finetune/intro.md
@@ -10,10 +10,10 @@ You could fine-tune an open-source LLM to
 * Teach it to respect and follow instructions.
 * Make it refuse to answer certain questions.
 * Give it a specific "speaking" style.
-* Make it response in certain formats (e.g., JSON).
+* Make it respond in certain formats (e.g., JSON).
 * Give it focus on a specific domain area.
 * Teach it certain knowledge.
 
 To do that, you need to create a set of question and answer pairs to show the model the prompt and the expected response.
-Then, you can use a fine-tuning tool to perform the training and make the model respond the expected answer for
+Then, you can use a fine-tuning tool to perform the training and make the model respond with the expected answer for
 each question.

--- a/versioned_docs/version-1.0.0/node-guide/tasks/aws.md
+++ b/versioned_docs/version-1.0.0/node-guide/tasks/aws.md
@@ -59,7 +59,7 @@ In the "Instance type" section, select an instance with at least 8GB of RAM. For
 
 In the "Network settings", make sure that you allow SSH connections.
 
-Click on the "Launch instance" button and wait for instance to start up. Once the instance is ready, SSH
+Click on the "Launch instance" button and wait for the instance to start up. Once the instance is ready, SSH
 into its public IP address. Once you are in the VM, run the following two commands.
 
 ```


### PR DESCRIPTION
In docs/intro.md:
Replaced "finetuned" with "fine-tuned" – correct hyphenated spelling.

In versioned_docs/version-1.0.0/creator-guide/finetune/intro.md:
Replaced "Make it response in certain formats" with "Make it respond in certain formats" – corrected verb usage.
Added the missing word "with" in "respond the expected answer", now reads "respond with the expected answer" – correct preposition for clarity.

In versioned_docs/version-1.0.0/node-guide/tasks/aws.md:
Added "the" in "wait for instance to start up", now reads "wait for the instance to start up" – grammatically correct phrase.