### PR TITLE
Fix: updated internal links for Docusaurus

### DIFF
--- a/docs/intro.md
+++ b/docs/intro.md
@@ -9,7 +9,7 @@ Gaia is a decentralized computing infrastructure that enables everyone to create
 It allows individuals and businesses to create AI agents. Each Gaia node provides:
 
 * a web-based chatbot UI [Chat with a Gaia node](https://rustcoder.gaia.domains/chatbot-ui/index.html) that is an expert on the Rust programming language.
-* an OpenAI compatible API. [See how](agent-integrations/intro) to use a Gaia node as a drop-in OpenAI replacement in your favorite AI agent app. 
+* an OpenAI compatible API. [See how](/agent-integrations/intro) to use a Gaia node as a drop-in OpenAI replacement in your favorite AI agent app. 
 
 100% of today's AI agents are applications in the OpenAI ecosystem. With our API approach, Gaia is an alternative to OpenAI. Each Gaia node has the ability to be customized with a fine-tuned model supplemented by domain knowledge which eliminates the generic responses many have come to expect. For example, a Gaia node for a financial analyst agent can write SQL code to query SEC 10K filings to respond to user questions. 
 
@@ -21,27 +21,27 @@ Similar Gaia nodes are organized into Gaia domains, to provide stable services b
 
 If you are an end user of AI agent applications, you can:
 
-* [Find a list of interesting Gaia nodes you can chat with on the web, or access via API](./nodes).
-* [Use a Gaia node as the backend AI engine for your favorite AI agent apps](./agent-integrations). 
+* [Find a list of interesting Gaia nodes you can chat with on the web, or access via API](/nodes).
+* [Use a Gaia node as the backend AI engine for your favorite AI agent apps](/agent-integrations). 
 
 ### Node operators
 
 If you are interested in running Gaia nodes, you can
 
-* [Get started with a Gaia node](./getting-started/quick-start).
-* [Customize the Gaia node with a finetuned model and custom knowledge base](./getting-started/customize).
-* [Join the Gaia Protocol](./getting-started/register)
+* [Get started with a Gaia node](/getting-started/quick-start).
+* [Customize the Gaia node with a finetuned model and custom knowledge base](/getting-started/customize).
+* [Join the Gaia Protocol](/getting-started/register)
 
 ### Domain operators
 
 If you are a Gaia Domain Name owner, you can
 
-* [Launch your domain](./domain-guide/quick-start.md).
+* [Launch your domain](/domain-guide/quick-start)
 
 
 ### Creators
 
 If you are a creator or knowledge worker interested in creating your own AI agent service, you can:
 
-* [Create your own knowledge base](./knowledge-bases).
-* [Finetune a model to "speak" like you](./tutorial/llamacpp).
+* [Create your own knowledge base](/knowledge-bases).
+* [Finetune a model to "speak" like you](/tutorial/llamacpp).


### PR DESCRIPTION
### Updated Internal Links for Better Compatibility
Hey,

This update fixes the internal links across the docs so they work properly on the live Gaia documentation site. 

Specifically:

- Removed .md extensions from internal links

- Changed relative paths (./something) to absolute paths (/something)

**![Screenshot 2025-06-25 083940](https://github.com/user-attachments/assets/eeeffef6-a2fd-4541-883d-8c181c1de0e8)**

Just a heads-up: some of these links might not work when you're browsing directly on GitHub (since GitHub expects .md and relative paths), but everything should work fine on the deployed site — which is what most users will be using anyway.

Let me know if anything looks off!

****