### PR TITLE
docs: Highlight WSL requirement for Windows users in node setup guide

### DIFF
--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -14,7 +14,10 @@ Before you get started, ensure that you have the following on your system:
 | Ubuntu Linux 20.04 with Nvidia CUDA 12 SDK | 8GB VRAM on GPU |
 | Azure/AWS | Nvidia T4 GPU Instance |
 
-Learn more about [system requirements](system-requirements). (Also Note when you're using a windows system you should have ubuntu installed so you use wsl in the command line)
+Learn more about [system requirements](system-requirements).
+
+**For Windows Users: Important Note on WSL (Windows Subsystem for Linux)**
+If you are using a Windows system, you **must** have [Windows Subsystem for Linux (WSL)](https://learn.microsoft.com/en-us/windows/wsl/install) installed and configured with an Ubuntu distribution. The installation commands for the Gaia node are Linux-based and require a Linux environment to run, which WSL provides on Windows.
 
 ### Installing the node
 


### PR DESCRIPTION


**Description:**

- Improves visibility of the Windows Subsystem for Linux (WSL) requirement in the
 [node setup guide](https://docs.gaianet.ai/getting-started/quick-start).

**Changes**

1. Added a dedicated section: **"For Windows Users: Important Note on WSL"** below the prerequisites.

- Clearly states the need for WSL and links to the official installation guide.

This helps Windows users avoid confusion by making the WSL requirement more noticeable.

### Before-

<img width="1362" height="718" alt="image" src="https://github.com/user-attachments/assets/cf9d862c-3fee-433b-9668-3be5c5002541" />

### After - 

<img width="1360" height="722" alt="image" src="https://github.com/user-attachments/assets/1760511e-228a-4bdb-8388-7c443fa3f81d" />



the text i added is - 
**For Windows Users: Important Note on WSL (Windows Subsystem for Linux)**
If you are using a Windows system, you **must** have [Windows Subsystem for Linux (WSL)](https://learn.microsoft.com/en-us/windows/wsl/install) installed and configured with an Ubuntu distribution. The installation commands for the Gaia node are Linux-based and require a Linux environment to run, which WSL provides on Windows.
